### PR TITLE
Change rules for prettier on endOfLine to auto

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,5 +17,12 @@
     "sourceType": "module"
   },
   "plugins": ["react"],
-  "rules": {}
+  "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
After switching from Ubuntu to Windows Prettier was founding lots of errors with End Of Line. To avoid constant formatting the rule was updated to "endOfLine":"auto"